### PR TITLE
Prevent NPE in convertFilterToFilterId

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -1066,6 +1066,9 @@ public class MXSession {
      * Either it is already known to the server, or send the filter to the server to get a filterId
      */
     private void convertFilterToFilterId() {
+        if (mEventsThread == null) {
+            return
+        }
         // Ensure mCurrentFilter has not been updated in the same time
         final String wantedJsonFilter = mCurrentFilter.toJSONString();
 


### PR DESCRIPTION
Before calling this method, a null check is made. SetSyncFilter is
a public method so mEventsThread could be null when calling
convertFilterToFilterId(). However setSyncFilter will be called once again
when instantiating mEventsThread.