### PR TITLE
Fix released session error when closing mxCrypto

### DIFF
--- a/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/CryptoStoreImportationTest.kt
+++ b/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/CryptoStoreImportationTest.kt
@@ -20,12 +20,20 @@ package org.matrix.androidsdk.crypto
 
 import android.support.test.InstrumentationRegistry
 import android.text.TextUtils
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
-import org.matrix.androidsdk.common.*
+import org.matrix.androidsdk.common.CommonTestHelper
+import org.matrix.androidsdk.common.CryptoTestHelper
+import org.matrix.androidsdk.common.SessionTestParams
+import org.matrix.androidsdk.common.TestApiCallback
+import org.matrix.androidsdk.common.TestConstants
 import org.matrix.androidsdk.crypto.data.MXDeviceInfo
 import org.matrix.androidsdk.crypto.data.MXOlmSession
 import org.matrix.androidsdk.data.RoomState
@@ -306,8 +314,8 @@ class CryptoStoreImportationTest {
         assertTrue(results.containsKey("onLiveEvent"))
 
         // Close alice and bob session
-        aliceSession.crypto!!.close()
-        bobSession.crypto!!.close()
+        aliceSession.crypto!!.close(aliceSession.dataHandler)
+        bobSession.crypto!!.close(bobSession.dataHandler)
 
         // Do not login, but instead create a new session
         val aliceSession2 = mTestHelper.createNewSession(aliceSession, sessionTestParamRealm)

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -659,8 +659,6 @@ public class MXSession {
      * Clear the application cache
      */
     private void clearApplicationCaches(Context context) {
-        mDataHandler.clear();
-
         // network event will not be listened anymore
         try {
             mContext.unregisterReceiver(mNetworkConnectivityReceiver);
@@ -676,8 +674,9 @@ public class MXSession {
         mMediaCache.clear();
 
         if (null != mCrypto) {
-            mCrypto.close();
+            mCrypto.close(mDataHandler);
         }
+        mDataHandler.clear();
     }
 
     /**
@@ -2448,7 +2447,7 @@ public class MXSession {
                 });
             } else if (null != mCrypto) {
                 Log.d(LOG_TAG, "Crypto is disabled");
-                mCrypto.close();
+                mCrypto.close(getDataHandler());
                 mCryptoStore.deleteStore();
                 mCrypto = null;
                 mDataHandler.setCrypto(null);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXCrypto.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXCrypto.java
@@ -29,6 +29,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 
+import org.matrix.androidsdk.MXDataHandler;
 import org.matrix.androidsdk.MXSession;
 import org.matrix.androidsdk.crypto.algorithms.IMXDecrypting;
 import org.matrix.androidsdk.crypto.algorithms.IMXEncrypting;
@@ -563,9 +564,9 @@ public class MXCrypto {
     /**
      * Close the crypto
      */
-    public void close() {
+    public void close(MXDataHandler dataHandler) {
         if (null != mEncryptingHandlerThread) {
-            mSession.getDataHandler().setCryptoEventsListener(null);
+            dataHandler.setCryptoEventsListener(null);
             getEncryptingThreadHandler().post(new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
Prevent error of already released session by passing dataHandler as an argument when closing mxCrypto