### PR TITLE
Add a custom type adapter to avoid deserializing int to double

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/json/ObjectMapDeserializer.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/json/ObjectMapDeserializer.kt
@@ -1,0 +1,63 @@
+package org.matrix.androidsdk.rest.json
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import com.google.gson.internal.LinkedTreeMap
+import java.lang.reflect.Type
+
+class ObjectMapDeserializer : JsonDeserializer<Map<String, Any>> {
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): Map<String, Any>? {
+        return read(json) as? Map<String, Any>
+    }
+
+    private fun read(input: JsonElement?): Any? {
+        return when {
+            input == null -> null
+            input.isJsonArray -> mapArray(input.asJsonArray)
+            input.isJsonObject -> mapObject(input.asJsonObject)
+            input.isJsonPrimitive -> mapPrimitive(input.asJsonPrimitive)
+            else -> null
+        }
+    }
+
+    private fun mapArray(jsonArray: JsonArray): Any {
+        return jsonArray.map { read(it) }
+    }
+
+    private fun mapObject(jsonObject: JsonObject): Any {
+        val result = LinkedTreeMap<String, Any>()
+        jsonObject.entrySet().forEach {
+            result.put(it.key, read(it.value))
+        }
+        return result
+    }
+
+    private fun mapPrimitive(jsonPrimitive: JsonPrimitive): Any? {
+        return when {
+            jsonPrimitive.isBoolean -> jsonPrimitive.asBoolean
+            jsonPrimitive.isString -> jsonPrimitive.asString
+            jsonPrimitive.isNumber -> mapNumber(jsonPrimitive.asString)
+            else -> null
+        }
+    }
+
+    private fun mapNumber(number: String): Any {
+        return try {
+            Integer.valueOf(number)
+        } catch (exception: NumberFormatException) {
+            try {
+                java.lang.Long.valueOf(number)
+            } catch (exception: NumberFormatException) {
+                number.toDouble()
+            }
+        }
+    }
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/util/JsonUtils.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/util/JsonUtils.java
@@ -30,6 +30,7 @@ import com.google.gson.reflect.TypeToken;
 import org.matrix.androidsdk.rest.json.BooleanDeserializer;
 import org.matrix.androidsdk.rest.json.ConditionDeserializer;
 import org.matrix.androidsdk.rest.json.MatrixFieldNamingStrategy;
+import org.matrix.androidsdk.rest.json.ObjectMapDeserializer;
 import org.matrix.androidsdk.rest.model.ContentResponse;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.EventContent;
@@ -86,6 +87,7 @@ public class JsonUtils {
             .registerTypeAdapter(Condition.class, new ConditionDeserializer())
             .registerTypeAdapter(boolean.class, new BooleanDeserializer(false))
             .registerTypeAdapter(Boolean.class, new BooleanDeserializer(true))
+            .registerTypeAdapter(new TypeToken<Map<String, Object>>(){}.getType(), new ObjectMapDeserializer())
             .create();
 
     // add a call to serializeNulls().


### PR DESCRIPTION
Create a custom Gson TypeAdapter.
It will prevent the parser to interprate all numbers as Double in a Map<String, Any> object.