### PR TITLE
Fix read receipts timestamp cast during sync

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -1227,8 +1227,13 @@ public class Room {
 
                             for (String paramName : paramsDict.keySet()) {
                                 if (TextUtils.equals("ts", paramName)) {
-                                    Double value = (Double) paramsDict.get(paramName);
-                                    long ts = value.longValue();
+                                    Object value = paramsDict.get(paramName);
+                                    long ts;
+                                    if (value instanceof Long) {
+                                        ts = ((Long) value);
+                                    } else {
+                                        ts = ((Double) value).longValue();
+                                    }
 
                                     if (handleReceiptData(new ReceiptData(userID, eventId, ts))) {
                                         senderIDs.add(userID);


### PR DESCRIPTION
Matrix sdk sync started crashing when receiving read receipts.
> java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.Double

Tolerate Long timestamp value as well as Double.